### PR TITLE
[preflight] new option --generate-only

### DIFF
--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -122,7 +122,7 @@ public class Application {
         }
 
         val preproc = preprocessor();
-        if (streamDefFilename != null) {
+        if (streamDefFilename != null) {   // preflight
             if (procUrl == null) {
                 System.err.println("missing argument: --process-url");
                 System.exit(1);
@@ -135,7 +135,13 @@ public class Application {
                 System.err.println("missing argument: --table-name");
                 System.exit(1);
             }
-            preflightRunner().run(streamDefFilename, procUrl, schemaName, tableName, generateOnly);
+            try {
+                preflightRunner().run(streamDefFilename, procUrl, schemaName, tableName, generateOnly);
+            }
+            catch (ApplicationError ex) {
+                System.err.println("preflight: error: " + ex.getMessage());
+                System.exit(1);
+            }
         }
         else if (procUrl != null) {
             val out = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -44,6 +44,7 @@ public class Application {
         String streamDefFilename = null;
         String schemaName = null;
         String tableName = null;
+        boolean generateOnly = false;
         boolean domainsReference = false;
 
         for (int i = 0; i < args.length; i++) {
@@ -90,6 +91,9 @@ public class Application {
                 }
                 procUrl = locatorFactory().parse(kv[1]);
             }
+            else if (args[i].equals("--generate-only")) {
+                generateOnly = true;
+            }
             else if (Objects.equals(args[i], "--domains-reference")) {
                 domainsReference = true;
             }
@@ -131,7 +135,7 @@ public class Application {
                 System.err.println("missing argument: --table-name");
                 System.exit(1);
             }
-            preflightRunner().run(streamDefFilename, procUrl, schemaName, tableName);
+            preflightRunner().run(streamDefFilename, procUrl, schemaName, tableName, generateOnly);
         }
         else if (procUrl != null) {
             val out = new BufferedWriter(new OutputStreamWriter(System.out));

--- a/src/main/java/org/bricolages/streaming/preflight/ObjectFilterGenerator.java
+++ b/src/main/java/org/bricolages/streaming/preflight/ObjectFilterGenerator.java
@@ -1,10 +1,10 @@
 package org.bricolages.streaming.preflight;
-
+import org.bricolages.streaming.filter.OperatorDefinition;
+import org.bricolages.streaming.ConfigError;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.bricolages.streaming.filter.OperatorDefinition;
 import lombok.*;
 
 class ObjectFilterGenerator {
@@ -24,11 +24,16 @@ class ObjectFilterGenerator {
 
     private Stream<OperatorDefinition> generateSingleColumnOperators(ColumnDefinitionEntry columnDef) {
         val columnName = columnDef.getColumName();
-        val opDefs = columnDef.getParams().getOperatorDefinitionEntries(columnName);
-        val ret = new ArrayList<OperatorDefinition>();
-        for(val opDef: opDefs) {
-            ret.add(new OperatorDefinition(opDef.getOperatorId(), opDef.getTargetColumn(), opDef.getParams(), ret.size() * 10));
+        try {
+            val opDefs = columnDef.getParams().getOperatorDefinitionEntries(columnName);
+            val ret = new ArrayList<OperatorDefinition>();
+            for (val opDef: opDefs) {
+                ret.add(new OperatorDefinition(opDef.getOperatorId(), opDef.getTargetColumn(), opDef.getParams(), ret.size() * 10));
+            }
+            return ret.stream();
         }
-        return ret.stream();
+        catch (ConfigError ex) {
+            throw new ConfigError(columnName + " column: " + ex.getMessage());
+        }
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/PreflightConfig.java
+++ b/src/main/java/org/bricolages/streaming/preflight/PreflightConfig.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
 import lombok.*;
 
+@NoArgsConstructor
+@AllArgsConstructor
 public class PreflightConfig {
     @Getter private DomainDefaultValues defaultValues;
 
@@ -18,5 +20,9 @@ public class PreflightConfig {
             .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
             .configure(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT, true);
         return mapper.readValue(yamlSource, PreflightConfig.class);
+    }
+
+    public static PreflightConfig defaultInstance() {
+        return new PreflightConfig(new DomainDefaultValues());
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/Runner.java
+++ b/src/main/java/org/bricolages/streaming/preflight/Runner.java
@@ -6,12 +6,14 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
+import java.io.FileNotFoundException;
 import org.apache.commons.io.FilenameUtils;
 import org.bricolages.streaming.Config;
 import org.bricolages.streaming.Preprocessor;
 import org.bricolages.streaming.SourceLocator;
 import org.bricolages.streaming.filter.FilterResult;
 import org.bricolages.streaming.filter.ObjectFilterFactory;
+import org.bricolages.streaming.filter.ObjectFilter;
 import org.bricolages.streaming.filter.OperatorDefinition;
 import org.bricolages.streaming.preflight.domains.DomainDefaultValues;
 import org.bricolages.streaming.s3.ObjectMapper;
@@ -35,29 +37,37 @@ public class Runner {
     }
 
     private PreflightConfig loadPreflightConfig(String defaultValuesFilePath) throws IOException {
-        val fileReader = new FileReader(defaultValuesFilePath);
-        return PreflightConfig.load(fileReader);
+        try {
+            val fileReader = new FileReader(defaultValuesFilePath);
+            return PreflightConfig.load(fileReader);
+        }
+        catch (FileNotFoundException ex) {
+            return PreflightConfig.defaultInstance();
+        }
     }
 
     private void saveCreateTableStmt(StreamDefinitionFile streamDefFile, StreamDefinitionEntry streamDef, String fullTableName) throws IOException {
         val createTableStmt = new CreateTableGenerator(streamDef, fullTableName).generate();
-        val filepath = streamDefFile.getCreateTableFilepath();
-        try(val writer = new BufferedWriter(new FileWriter(filepath))) {
+        val path = streamDefFile.getCreateTableFilepath();
+        System.err.printf("generating table def: %s\n", path.toString());
+        try(val writer = new BufferedWriter(new FileWriter(path))) {
             writer.write(createTableStmt);
         }
     }
 
     private void saveOperatorDefinitions(StreamDefinitionFile streamDefFile, String streamName, List<OperatorDefinition> operators) throws IOException {
-        val filepath = streamDefFile.getOperatorDefinitionsFilepath();
-        try (val preprocCsvFile = new FileOutputStream(filepath)) {
+        val path = streamDefFile.getOperatorDefinitionsFilepath();
+        System.err.printf("generating preproc def: %s\n", path.toString());
+        try (val preprocCsvFile = new FileOutputStream(path)) {
             val serializer = new ObjectFilterSerializer(preprocCsvFile);
             serializer.serialize(streamName, operators);
         }
     }
 
     private void saveLoadJob(StreamDefinitionFile streamDefFile, S3ObjectLocation dest, String fullTableName) throws IOException {
-        val filepath = streamDefFile.getLoadJobFilepath();
-        try (val loadJobFile = new FileOutputStream(filepath)) {
+        val path = streamDefFile.getLoadJobFilepath();
+        System.err.printf("generating load job: %s\n", path.toString());
+        try (val loadJobFile = new FileOutputStream(path)) {
             new LoadJobSerializer(loadJobFile).serialize(dest, streamDefFile.getCreateTableFilepath(), fullTableName, config.getSrcDs(), config.getDestDs());
         }
     }
@@ -88,28 +98,36 @@ public class Runner {
         }
     }
 
-    public void run(String streamDefFilename, SourceLocator src, String schemaName, String tableName) throws IOException, S3IOException {
+    public void run(String streamDefFilename, SourceLocator src, String schemaName, String tableName, boolean generateOnly) throws IOException, S3IOException {
         val preflightConfig = loadPreflightConfig("config/preflight.yml");
-        val fullTableName = schemaName + "." + tableName;
         val streamDefFile = new StreamDefinitionFile(streamDefFilename);
         val streamDef = loadStreamDef(streamDefFile);
         streamDef.applyDefaultValues(preflightConfig.getDefaultValues());
-        System.err.printf("     source: %s\n", src.toString());
 
         val mapping = mapper.map(src.toString());
         val dest = mapping.getDestLocation();
-        System.err.printf("destination: %s\n", dest.toString());
+        val streamName = mapping.getStreamName();
 
         val generator = new ObjectFilterGenerator(streamDef);
         val operators = generator.generate();
         val filter = factory.compose(operators);
-        val result = new FilterResult(src.toString(), dest.urlString());
-        val streamName = mapping.getStreamName();
-        preprocessor.applyFilter(filter, src, dest, result, streamName);
-        System.err.printf("     result: input rows=%d, output rows=%d, error rows=%d\n", result.inputRows, result.outputRows, result.errorRows);
-
         saveOperatorDefinitions(streamDefFile, streamName, operators);
+
+        val fullTableName = schemaName + "." + tableName;
         saveCreateTableStmt(streamDefFile, streamDef, fullTableName);
         saveLoadJob(streamDefFile, dest, fullTableName);
+
+        if (!generateOnly) {
+            applyFilter(filter, src, dest, streamName);
+        }
+    }
+
+    void applyFilter(ObjectFilter filter, SourceLocator src, S3ObjectLocation dest, String streamName) throws IOException, S3IOException {
+        System.err.printf("*** preproc start");
+        System.err.printf("preproc source     : %s\n", src.toString());
+        System.err.printf("preproc destination: %s\n", dest.toString());
+        val result = new FilterResult(src.toString(), dest.urlString());
+        preprocessor.applyFilter(filter, src, dest, result, streamName);
+        System.err.printf("*** preproc succeeded: in=%d, out=%d, error=%d\n", result.inputRows, result.outputRows, result.errorRows);
     }
 }

--- a/src/main/java/org/bricolages/streaming/preflight/Runner.java
+++ b/src/main/java/org/bricolages/streaming/preflight/Runner.java
@@ -20,6 +20,7 @@ import org.bricolages.streaming.s3.ObjectMapper;
 import org.bricolages.streaming.s3.S3Agent;
 import org.bricolages.streaming.s3.S3IOException;
 import org.bricolages.streaming.s3.S3ObjectLocation;
+import org.bricolages.streaming.ConfigError;
 
 import lombok.*;
 
@@ -105,6 +106,9 @@ public class Runner {
         streamDef.applyDefaultValues(preflightConfig.getDefaultValues());
 
         val mapping = mapper.map(src.toString());
+        if (mapping == null) {
+            throw new ConfigError("could not map source URL");
+        }
         val dest = mapping.getDestLocation();
         val streamName = mapping.getStreamName();
 

--- a/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DateDomain.java
@@ -20,7 +20,6 @@ public class DateDomain implements ColumnParametersEntry {
 
     public List<OperatorDefinitionEntry> getOperatorDefinitionEntries(String columnName) {
         val list = new ArrayList<OperatorDefinitionEntry>();
-        list.add(new OperatorDefinitionEntry("date", columnName, null));
         return list;
     }
 

--- a/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/LogTimeDomain.java
@@ -1,5 +1,4 @@
 package org.bricolages.streaming.preflight.domains;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.bricolages.streaming.filter.RenameOp;
@@ -8,6 +7,7 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
+import org.bricolages.streaming.ConfigError;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
@@ -33,6 +33,12 @@ public class LogTimeDomain implements ColumnParametersEntry {
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
     public List<OperatorDefinitionEntry> getOperatorDefinitionEntries(String columnName) {
+        if (sourceOffset == null) {
+            throw new ConfigError("missing paramter: sourceOffset");
+        }
+        if (targetOffset == null) {
+            throw new ConfigError("missing paramter: targetOffset");
+        }
         val tzParams = new TimeZoneOp.Parameters();
         tzParams.setSourceOffset(sourceOffset);
         tzParams.setTargetOffset(targetOffset);

--- a/src/main/java/org/bricolages/streaming/preflight/domains/TimestampDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/TimestampDomain.java
@@ -7,6 +7,7 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
+import org.bricolages.streaming.ConfigError;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
@@ -27,6 +28,12 @@ public class TimestampDomain implements ColumnParametersEntry {
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
     public List<OperatorDefinitionEntry> getOperatorDefinitionEntries(String columnName) {
+        if (sourceOffset == null) {
+            throw new ConfigError("missing parameter: sourceOffset");
+        }
+        if (targetOffset == null) {
+            throw new ConfigError("missing parameter: targetOffset");
+        }
         val params = new TimeZoneOp.Parameters();
         params.setSourceOffset(sourceOffset);
         params.setTargetOffset(targetOffset);

--- a/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
@@ -1,5 +1,4 @@
 package org.bricolages.streaming.preflight.domains;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.bricolages.streaming.filter.UnixTimeOp;
@@ -7,6 +6,7 @@ import org.bricolages.streaming.preflight.ColumnEncoding;
 import org.bricolages.streaming.preflight.ColumnParametersEntry;
 import org.bricolages.streaming.preflight.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
+import org.bricolages.streaming.ConfigError;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
@@ -23,6 +23,9 @@ public class UnixtimeDomain implements ColumnParametersEntry {
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
     public List<OperatorDefinitionEntry> getOperatorDefinitionEntries(String columnName) {
+        if (zoneOffset == null) {
+            throw new ConfigError("missing parameter: zoneOffset");
+        }
         val utParams = new UnixTimeOp.Parameters();
         utParams.setZoneOffset(zoneOffset);
         val list = new ArrayList<OperatorDefinitionEntry>();


### PR DESCRIPTION
- ファイル生成だけしてpreprocを実施しないオプション --generate-only を追加
- すべてのファイルを出力するときにメッセージを出力
- opのパラメーターがない場合にちゃんとエラーメッセージを出すよう変更
- config/preflight.ymlがないときにちゃんとエラーメッセージを出すよう変更

@KOBA789 