### PR TITLE
Ignores ObjectCreated:Copy events

### DIFF
--- a/src/main/java/org/bricolages/streaming/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/Preprocessor.java
@@ -180,6 +180,11 @@ public class Preprocessor implements EventHandlers {
     @Override
     public void handleS3Event(S3Event event) {
         log.debug("handling URL: {}", event.getLocation().toString());
+        if (event.isCopyEvent()) {
+            log.info("remove CopyEvent: {}", event.toString());
+            eventQueue.deleteAsync(event);
+            return;
+        }
         S3ObjectLocation src = event.getLocation();
         String srcBucket = src.bucket();
         val mapResult = mapper.map(src.urlString());

--- a/src/test/java/org/bricolages/streaming/event/S3EventTest.java
+++ b/src/test/java/org/bricolages/streaming/event/S3EventTest.java
@@ -1,0 +1,22 @@
+package org.bricolages.streaming.event;
+import org.junit.Test;
+import com.amazonaws.services.sqs.model.Message;
+import static org.junit.Assert.*;
+import lombok.*;
+
+public class S3EventTest {
+    @Test
+    public void isCopyEvent() throws Exception {
+        val e = parseEvent("{\"Records\":[{\"eventVersion\":\"2.0\",\"eventSource\":\"bricolage:preprocessor\",\"eventTime\":\"2016-09-06T13:52:49Z\",\"eventName\":\"ObjectCreated:Put\",\"s3\":{\"s3SchemaVersion\":\"1.0\",\"bucket\":{\"name\":\"test-bucket\"},\"object\":{\"key\":\"test-prefix/test-file.json.gz\",\"size\":\"1358\",\"eTag\":\"bfa868a9c00376f6704f41d6a9e0da20\"}}}]}");
+        assertEquals(false, e.isCopyEvent());
+
+        val e2 = parseEvent("{\"Records\":[{\"eventVersion\":\"2.0\",\"eventSource\":\"bricolage:preprocessor\",\"eventTime\":\"2016-09-06T13:52:49Z\",\"eventName\":\"ObjectCreated:Copy\",\"s3\":{\"s3SchemaVersion\":\"1.0\",\"bucket\":{\"name\":\"test-bucket\"},\"object\":{\"key\":\"test-prefix/test-file.json.gz\",\"size\":\"1358\",\"eTag\":\"bfa868a9c00376f6704f41d6a9e0da20\"}}}]}");
+        assertEquals(true, e2.isCopyEvent());
+    }
+
+    S3Event parseEvent(String body) throws Exception {
+        val msg = new Message();
+        msg.setBody(body);
+        return S3Event.forMessage(msg);
+    }
+}


### PR DESCRIPTION
ObjectCreated:Copy events are almost generated by people, not logging system (e.g. fluentd), we should just ignore them.