### PR TITLE
Routes S3 objects by strload_stream_bundles

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,17 +1,20 @@
 buildscript {
+    ext {
+        springBootVersion = '1.5.8.RELEASE'
+    }
     repositories {
         mavenCentral()
     }
     dependencies {
-        classpath "io.spring.gradle:dependency-management-plugin:0.5.4.RELEASE"
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.3.5.RELEASE"
+        classpath "io.spring.gradle:dependency-management-plugin:1.0.3.RELEASE"
+        classpath "org.springframework.boot:spring-boot-gradle-plugin:1.5.8.RELEASE"
     }
 }
 
 apply plugin: 'io.spring.dependency-management'
 apply plugin: 'java'
 apply plugin: 'application'
-apply plugin: 'spring-boot'
+apply plugin: 'org.springframework.boot'
 apply plugin: 'maven'
 
 group 'org.bricolages.streaming'
@@ -57,6 +60,8 @@ dependencies {
     compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.16.18'
     testCompile group: 'org.projectlombok', name: 'lombok', version: '1.16.18'
     testCompile group: 'junit', name: 'junit', version: '4.12'
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: '1.5.8.RELEASE'
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-test-autoconfigure', version: '1.5.8.RELEASE'
 }
 
 ///// xjar //////////////////////////////////////////////////////////////////////////////

--- a/build.gradle
+++ b/build.gradle
@@ -86,5 +86,5 @@ test {
 
 uploadArchives.repositories.mavenDeployer {
     repository url: "$System.env.MAVEN_REPO"
-    pom.version = "1.2.1"
+    pom.version = "1.2.2"
 }

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -13,9 +13,6 @@ spring:
         time-between-eviction-runs-millis: 60000
         validation-query: "select 1"
 
-flyway:
-    enabled: false
-
 bricolage:
     event-queue:
         url: ${bricolage.event.queue.url}

--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -118,7 +118,7 @@ public class Application {
         }
 
         if (mapUrl != null) {
-            val result = mapper().map(mapUrl.toString());
+            val result = mapper().mapByPatterns(mapUrl.toString());
             System.out.println(result.getDestLocation());
             System.exit(0);
         }

--- a/src/main/java/org/bricolages/streaming/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/Preprocessor.java
@@ -57,7 +57,7 @@ public class Preprocessor implements EventHandlers {
     }
 
     public boolean processUrl(SourceLocator src, BufferedWriter out) {
-        val mapResult = mapper.map(src.toString());
+        val mapResult = mapper.mapByPatterns(src.toString());
         if (mapResult == null) {
             log.warn("S3 object could not mapped: {}", src);
             return false;
@@ -188,7 +188,7 @@ public class Preprocessor implements EventHandlers {
         }
         S3ObjectLocation src = event.getLocation();
         String srcBucket = src.bucket();
-        val mapResult = mapper.map(src.urlString());
+        val mapResult = mapper.map(src);
         if (mapResult == null) {
             // object mapping failed; this means invalid event or bad configuration.
             // We should remove invalid events from queue and

--- a/src/main/java/org/bricolages/streaming/StreamBundle.java
+++ b/src/main/java/org/bricolages/streaming/StreamBundle.java
@@ -35,7 +35,7 @@ public class StreamBundle {
     @Getter
     String destPrefix;
 
-    StreamBundle(DataStream stream, String bucket, String prefix, String destBucket, String destPrefix) {
+    public StreamBundle(DataStream stream, String bucket, String prefix, String destBucket, String destPrefix) {
         this.stream = stream;
         this.bucket = bucket;
         this.prefix = prefix;

--- a/src/main/java/org/bricolages/streaming/StreamBundleRepository.java
+++ b/src/main/java/org/bricolages/streaming/StreamBundleRepository.java
@@ -1,5 +1,4 @@
 package org.bricolages.streaming;
-
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import lombok.*;
@@ -12,6 +11,17 @@ public interface StreamBundleRepository extends JpaRepository<StreamBundle, Long
         if (list.isEmpty()) return null;
         if (list.size() > 1) {
             throw new ApplicationError("FATAL: multiple stream bundle matched: " + stream.id + ", " + prefix);
+        }
+        return list.get(0);
+    }
+
+    List<StreamBundle> findByBucketAndPrefix(String bucket, String prefix);
+
+    default StreamBundle findStreamBundle(String bucket, String prefix) {
+        val list = findByBucketAndPrefix(bucket, prefix);
+        if (list.isEmpty()) return null;
+        if (list.size() > 1) {
+            throw new ApplicationError("FATAL: multiple stream bundle matched: bucket=" + bucket + ", prefix=" + prefix);
         }
         return list.get(0);
     }

--- a/src/main/java/org/bricolages/streaming/preflight/Runner.java
+++ b/src/main/java/org/bricolages/streaming/preflight/Runner.java
@@ -113,7 +113,7 @@ public class Runner {
         val wellknownColumnCollection = loadWellknownCollumnCollection("config/wellknown_columns.yml", domainCollection);
         val streamDef = loadStreamDef(streamDefFile, domainCollection, wellknownColumnCollection);
 
-        val mapping = mapper.map(src.toString());
+        val mapping = mapper.mapByPatterns(src.toString());
         if (mapping == null) {
             throw new ConfigError("could not map source URL");
         }

--- a/src/main/java/org/bricolages/streaming/s3/ObjectMapper.java
+++ b/src/main/java/org/bricolages/streaming/s3/ObjectMapper.java
@@ -48,16 +48,24 @@ public class ObjectMapper {
     @Autowired
     StreamBundleRepository streamBundleRepos;
 
+    /**
+     * Expects URL like: s3://src-bucket/prefix1/prefix2/prefix3/.../YYYY/MM/DD/objectName.gz
+     * streamPrefix: "prefix1/prefix2/prefix3/..."
+     * objectPrefix: "YYYY/MM/DD"
+     * objectName: "objectName.gz"
+     */
     Result mapByPrefix(String bucket, String key) {
         val components = key.split("/");
-        if (components.length < 3) {
+        if (components.length < 5) {
             logUnknownS3Object("s3://" + bucket + "/" + key);
             return null;
         }
-        val prefix = components[0];
+        String[] prefixComponents = Arrays.copyOfRange(components, 0, components.length - 4);
+        val prefix = String.join("/", prefixComponents);
+        String[] objPrefixComponents = Arrays.copyOfRange(components, components.length - 4, components.length - 1);
+        val objPrefix = String.join("/", objPrefixComponents);
         val objName = components[components.length - 1];
-        String[] prefixes = Arrays.copyOfRange(components, 1, components.length - 1);
-        val objPrefix = String.join("/", prefixes);
+        log.debug("parsed url: prefix={}, objPrefix={}, objName={}", prefix, objPrefix, objName);
 
         val bundle = streamBundleRepos.findStreamBundle(bucket, prefix);
         if (bundle == null) return null;

--- a/src/test/java/org/bricolages/streaming/TestApplication.java
+++ b/src/test/java/org/bricolages/streaming/TestApplication.java
@@ -1,0 +1,12 @@
+package org.bricolages.streaming;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TestApplication {
+    @Test public void loadContext() {
+    }
+}

--- a/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
+++ b/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
@@ -22,27 +22,27 @@ public class ObjectMapperTest {
     public void map() throws Exception {
         val map = newMapper(entry("s3://src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$1", "src-prefix", "dest-bucket", "dest-prefix/$1", "", "$2"));
         map.check();
-        val result = map.map("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
+        val result = map.mapByPatterns("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
         assertEquals(loc("s3://dest-bucket/dest-prefix/schema.table/datafile.json.gz"), result.getDestLocation());
         assertEquals("schema.table", result.getStreamName());
-        assertNull(map.map("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
+        assertNull(map.mapByPatterns("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
     }
 
     @Test
     public void map_localfile() throws Exception {
         val map = newMapper(entry("file:/(?:.+/)?src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$1", "src-prefix", "dest-bucket", "dest-prefix/$1", "", "$2"));
         map.check();
-        val result = map.map("file:/path/to/src-bucket/src-prefix/schema.table/datafile.json.gz");
+        val result = map.mapByPatterns("file:/path/to/src-bucket/src-prefix/schema.table/datafile.json.gz");
         assertEquals(loc("s3://dest-bucket/dest-prefix/schema.table/datafile.json.gz"), result.getDestLocation());
         assertEquals("schema.table", result.getStreamName());
-        assertNull(map.map("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
+        assertNull(map.mapByPatterns("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
     }
     
     @Test(expected=ConfigError.class)
     public void map_baddest() throws Exception {
         val map = newMapper(entry("s3://src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$3", "src-prefix", "dest-bucket", "dest-prefix/$1", "", "$2"));
         map.check();
-        map.map("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
+        map.mapByPatterns("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
     }
 
     @Test(expected=ConfigError.class)

--- a/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
+++ b/src/test/java/org/bricolages/streaming/s3/ObjectMapperTest.java
@@ -32,6 +32,7 @@ public class ObjectMapperTest {
         val map = newRouter(entry("s3://src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$1", "src-prefix", "dest-bucket", "dest-prefix/$1", "", "$2"));
         map.check();
         val result = map.mapByPatterns("s3://src-bucket/src-prefix/schema.table/datafile.json.gz");
+        assertNotNull(result);
         assertEquals(loc("s3://dest-bucket/dest-prefix/schema.table/datafile.json.gz"), result.getDestLocation());
         assertEquals("schema.table", result.getStreamName());
         assertNull(map.mapByPatterns("s3://src-bucket-2/src-prefix/schema.table/datafile.json.gz"));
@@ -68,15 +69,16 @@ public class ObjectMapperTest {
     public void map() throws Exception {
         entityManager.persist(new DataStream("schema.table"));
         val stream = streamRepos.findStream("schema.table");
-        entityManager.persist(new StreamBundle(stream, "src-bucket-2", "src-prefix-2", "dest-bucket-2", "dest-prefix-2"));
+        entityManager.persist(new StreamBundle(stream, "src-bucket", "0000.schema.table_2", "dest-bucket-2", "dest-prefix-2"));
         val bundle = bundleRepos.findStreamBundle("src-bucket-2", "src-prefix-2");
 
-        val router = newRouter(entry("file:/(?:.+/)?src-bucket/src-prefix/(schema\\.table)/(.*\\.gz)", "$1", "src-prefix", "dest-bucket", "dest-prefix/$1", "", "$2"));
+        val router = newRouter(entry("s3://src-bucket/(0000.(schema\\.table))/(2017/11/28)/(.*\\.gz)", "$2", "$1", "dest-bucket", "dest/$1", "$2", "$3"));
         router.check();
 
-        val result = router.map(loc("s3://src-bucket-2/src-prefix-2/schema.table/datafile.json.gz"));
-        assertEquals(loc("s3://dest-bucket-2/dest-prefix-2/schema.table/datafile.json.gz"), result.getDestLocation());
+        val result = router.map(loc("s3://src-bucket/0000.schema.table_2/2017/11/28/datafile.json.gz"));
+        assertNotNull(result);
         assertEquals("schema.table", result.getStreamName());
+        assertEquals(loc("s3://dest-bucket-2/dest-prefix-2/2017/11/28/datafile.json.gz"), result.getDestLocation());
 
         assertNull(router.map(loc("s3://src-bucket-UNKNOWN/src-prefix-UNKNOWN/schema.table/datafile.json.gz")));
         assertNull(router.map(loc("s3://src-bucket-2/datafile.json.gz")));


### PR DESCRIPTION
これまでオブジェクトの書き込み先はapplication.yamlに登録した正規表現でマッチして決定していましたが、それに加えて、strload_stream_bundlesによるルーティングも追加します。

これにより、例えば _raw suffix付きテーブルのオブジェクトを _raw suffixなしテーブルへマージさせることができるようになります。言い方を変えると、複数のストリームで1つのfilter定義（opの集合）を共有できるようになります。一言で言うとストリームをマージできるようになるということです。

## ロジック
1. バケット名と、オブジェクトのprefixの最初の部分（スラッシュで分けた最初のパート）でstrload_stream_bundlesを引く。見付かったらそのbundleのdest_bucket, dest_prefixを使う。
2. 既存の正規表現マッチによるルーティングを行う。

@KOBA789 @shimpeko @inohiro レビューお願いします。