### PR TITLE
refactoring: new packages: stream, locator, exception

### DIFF
--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -1,14 +1,12 @@
 package org.bricolages.streaming;
-import org.bricolages.streaming.filter.ObjectFilterFactory;
-import org.bricolages.streaming.filter.OpBuilder;
+import org.bricolages.streaming.filter.*;
+import org.bricolages.streaming.event.*;
+import org.bricolages.streaming.stream.*;
+import org.bricolages.streaming.locator.*;
+import org.bricolages.streaming.s3.*;
+import org.bricolages.streaming.exception.*;
 import org.bricolages.streaming.preflight.ReferenceGenerator;
 import org.bricolages.streaming.preflight.Runner;
-import org.bricolages.streaming.event.EventQueue;
-import org.bricolages.streaming.event.LogQueue;
-import org.bricolages.streaming.event.SQSQueue;
-import org.bricolages.streaming.s3.S3Agent;
-import org.bricolages.streaming.s3.ObjectMapper;
-import org.bricolages.streaming.s3.S3ObjectLocation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -118,7 +116,7 @@ public class Application {
         }
 
         if (mapUrl != null) {
-            val result = mapper().mapByPatterns(mapUrl.toString());
+            val result = router().mapByPatterns(mapUrl.toString());
             System.out.println(result.getDestLocation());
             System.exit(0);
         }
@@ -183,12 +181,12 @@ public class Application {
 
     @Bean
     public Runner preflightRunner() {
-        return new Runner(preprocessor(), filterFactory(), s3(), mapper(), config);
+        return new Runner(preprocessor(), filterFactory(), s3(), router(), config);
     }
 
     @Bean
     public Preprocessor preprocessor() {
-        return new Preprocessor(eventQueue(), logQueue(), s3(), mapper(), filterFactory());
+        return new Preprocessor(eventQueue(), logQueue(), s3(), router(), filterFactory());
     }
 
     @Bean
@@ -214,8 +212,8 @@ public class Application {
     }
 
     @Bean
-    public ObjectMapper mapper() {
-        return new ObjectMapper(this.config.getMappings());
+    public DataPacketRouter router() {
+        return new DataPacketRouter(this.config.getRoutes());
     }
 
     @Bean

--- a/src/main/java/org/bricolages/streaming/Config.java
+++ b/src/main/java/org/bricolages/streaming/Config.java
@@ -1,12 +1,9 @@
 package org.bricolages.streaming;
-
 import lombok.Getter;
 import lombok.Setter;
-
-import org.bricolages.streaming.s3.ObjectMapper;
+import org.bricolages.streaming.stream.DataPacketRouter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,7 +15,7 @@ public class Config {
     @Getter
     private final LogQueue logQueue = new LogQueue();
     @Getter
-    private List<ObjectMapper.Entry> mappings = new ArrayList<>();
+    private List<DataPacketRouter.Entry> routes = new ArrayList<>();
 
     @Setter
     static class EventQueue {

--- a/src/main/java/org/bricolages/streaming/event/MessageParseException.java
+++ b/src/main/java/org/bricolages/streaming/event/MessageParseException.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.event;
-import org.bricolages.streaming.ApplicationException;
+import org.bricolages.streaming.exception.ApplicationException;
 
 public class MessageParseException extends ApplicationException {
     MessageParseException(String message) {

--- a/src/main/java/org/bricolages/streaming/event/SQSException.java
+++ b/src/main/java/org/bricolages/streaming/event/SQSException.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.event;
-import org.bricolages.streaming.ApplicationError;
+import org.bricolages.streaming.exception.ApplicationError;
 
 public class SQSException extends ApplicationError {
     SQSException(String message) {

--- a/src/main/java/org/bricolages/streaming/event/SQSQueue.java
+++ b/src/main/java/org/bricolages/streaming/event/SQSQueue.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.event;
-import org.bricolages.streaming.ApplicationAbort;
+import org.bricolages.streaming.exception.ApplicationAbort;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;

--- a/src/main/java/org/bricolages/streaming/exception/ApplicationAbort.java
+++ b/src/main/java/org/bricolages/streaming/exception/ApplicationAbort.java
@@ -1,4 +1,4 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.exception;
 
 public class ApplicationAbort extends ApplicationError {
     public ApplicationAbort(String message) {

--- a/src/main/java/org/bricolages/streaming/exception/ApplicationError.java
+++ b/src/main/java/org/bricolages/streaming/exception/ApplicationError.java
@@ -1,4 +1,4 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.exception;
 
 public class ApplicationError extends RuntimeException {
     public ApplicationError(String message) {

--- a/src/main/java/org/bricolages/streaming/exception/ApplicationException.java
+++ b/src/main/java/org/bricolages/streaming/exception/ApplicationException.java
@@ -1,4 +1,4 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.exception;
 
 public class ApplicationException extends Exception {
     public ApplicationException(String message) {

--- a/src/main/java/org/bricolages/streaming/exception/ConfigError.java
+++ b/src/main/java/org/bricolages/streaming/exception/ConfigError.java
@@ -1,4 +1,4 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.exception;
 
 public class ConfigError extends ApplicationError {
     public ConfigError(String message) {

--- a/src/main/java/org/bricolages/streaming/filter/FilterException.java
+++ b/src/main/java/org/bricolages/streaming/filter/FilterException.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.filter;
-import org.bricolages.streaming.ApplicationException;
+import org.bricolages.streaming.exception.ApplicationException;
 
 public class FilterException extends ApplicationException {
     FilterException(String message) {

--- a/src/main/java/org/bricolages/streaming/filter/JSONException.java
+++ b/src/main/java/org/bricolages/streaming/filter/JSONException.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.filter;
-import org.bricolages.streaming.ApplicationException;
+import org.bricolages.streaming.exception.ApplicationException;
 
 public class JSONException extends ApplicationException {
     JSONException(String message) {

--- a/src/main/java/org/bricolages/streaming/filter/ObjectFilterFactory.java
+++ b/src/main/java/org/bricolages/streaming/filter/ObjectFilterFactory.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.filter;
-import org.bricolages.streaming.DataStreamRepository;
+import org.bricolages.streaming.stream.DataStreamRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/org/bricolages/streaming/filter/OpBuilder.java
+++ b/src/main/java/org/bricolages/streaming/filter/OpBuilder.java
@@ -3,8 +3,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import org.bricolages.streaming.ConfigError;
-import org.bricolages.streaming.SequencialNumberRepository;
+import org.bricolages.streaming.exception.ConfigError;
 
 import lombok.*;
 

--- a/src/main/java/org/bricolages/streaming/filter/OperatorDefinition.java
+++ b/src/main/java/org/bricolages/streaming/filter/OperatorDefinition.java
@@ -1,6 +1,6 @@
 package org.bricolages.streaming.filter;
-import org.bricolages.streaming.ConfigError;
-import org.bricolages.streaming.DataStream;
+import org.bricolages.streaming.exception.ConfigError;
+import org.bricolages.streaming.stream.DataStream;
 import javax.persistence.*;
 import java.util.List;
 import java.io.IOException;

--- a/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
@@ -1,7 +1,5 @@
 package org.bricolages.streaming.filter;
-
-import org.bricolages.streaming.ApplicationError;
-import org.bricolages.streaming.SequencialNumberRepository;
+import org.bricolages.streaming.exception.ApplicationError;
 import lombok.*;
 
 public class SequenceOp extends SingleColumnOp {

--- a/src/main/java/org/bricolages/streaming/filter/SequencialNumber.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequencialNumber.java
@@ -1,4 +1,4 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.filter;
 import javax.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/bricolages/streaming/filter/SequencialNumberRepository.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequencialNumberRepository.java
@@ -1,5 +1,4 @@
-package org.bricolages.streaming;
-
+package org.bricolages.streaming.filter;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import lombok.*;

--- a/src/main/java/org/bricolages/streaming/locator/LocalFileSourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/locator/LocalFileSourceLocator.java
@@ -1,5 +1,4 @@
-package org.bricolages.streaming;
-
+package org.bricolages.streaming.locator;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -10,7 +9,6 @@ import java.io.Reader;
 import java.net.URI;
 import java.nio.file.Paths;
 import java.util.zip.GZIPInputStream;
-
 import lombok.*;
 
 public class LocalFileSourceLocator implements SourceLocator {

--- a/src/main/java/org/bricolages/streaming/locator/LocatorFactory.java
+++ b/src/main/java/org/bricolages/streaming/locator/LocatorFactory.java
@@ -1,18 +1,17 @@
-package org.bricolages.streaming;
-
+package org.bricolages.streaming.locator;
+import org.bricolages.streaming.s3.S3Agent;
+import org.bricolages.streaming.s3.S3ObjectLocation;
+import org.bricolages.streaming.exception.*;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import org.bricolages.streaming.s3.S3Agent;
-import org.bricolages.streaming.s3.S3ObjectLocation;
-
 import lombok.*;
 
 @RequiredArgsConstructor
 public class LocatorFactory {
     final S3Agent s3agent;
 
-    SourceLocator parse(String urlString) throws URISyntaxException, IOException {
+    public SourceLocator parse(String urlString) throws URISyntaxException, IOException {
         val uri = new URI(urlString);
         val scheme = uri.getScheme();
         if (scheme == null) {

--- a/src/main/java/org/bricolages/streaming/locator/S3ObjectSourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/locator/S3ObjectSourceLocator.java
@@ -1,8 +1,6 @@
-package org.bricolages.streaming;
-
+package org.bricolages.streaming.locator;
 import java.io.BufferedReader;
 import java.io.IOException;
-
 import org.bricolages.streaming.s3.S3Agent;
 import org.bricolages.streaming.s3.S3IOException;
 import org.bricolages.streaming.s3.S3ObjectLocation;
@@ -11,7 +9,7 @@ public class S3ObjectSourceLocator implements SourceLocator {
     private final S3Agent agent;
     private final S3ObjectLocation location;
 
-    S3ObjectSourceLocator(S3Agent agent, S3ObjectLocation location) {
+    public S3ObjectSourceLocator(S3Agent agent, S3ObjectLocation location) {
         this.agent = agent;
         this.location = location;
     }

--- a/src/main/java/org/bricolages/streaming/locator/SourceLocator.java
+++ b/src/main/java/org/bricolages/streaming/locator/SourceLocator.java
@@ -1,5 +1,4 @@
-package org.bricolages.streaming;
-
+package org.bricolages.streaming.locator;
 import java.io.BufferedReader;
 import java.io.IOException;
 

--- a/src/main/java/org/bricolages/streaming/preflight/ObjectFilterGenerator.java
+++ b/src/main/java/org/bricolages/streaming/preflight/ObjectFilterGenerator.java
@@ -4,7 +4,7 @@ import org.bricolages.streaming.filter.RenameOp;
 import org.bricolages.streaming.preflight.definition.ColumnDefinition;
 import org.bricolages.streaming.preflight.definition.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.definition.StreamDefinitionEntry;
-import org.bricolages.streaming.ConfigError;
+import org.bricolages.streaming.exception.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/org/bricolages/streaming/preflight/domains/TimestampDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/TimestampDomain.java
@@ -1,12 +1,11 @@
 package org.bricolages.streaming.preflight.domains;
-
-import java.util.ArrayList;
-import java.util.List;
 import org.bricolages.streaming.filter.TimeZoneOp;
 import org.bricolages.streaming.preflight.definition.ColumnEncoding;
 import org.bricolages.streaming.preflight.definition.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
-import org.bricolages.streaming.ConfigError;
+import org.bricolages.streaming.exception.ConfigError;
+import java.util.ArrayList;
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;

--- a/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/UnixtimeDomain.java
@@ -1,11 +1,11 @@
 package org.bricolages.streaming.preflight.domains;
-import java.util.ArrayList;
-import java.util.List;
 import org.bricolages.streaming.filter.UnixTimeOp;
 import org.bricolages.streaming.preflight.definition.ColumnEncoding;
 import org.bricolages.streaming.preflight.definition.OperatorDefinitionEntry;
 import org.bricolages.streaming.preflight.ReferenceGenerator.MultilineDescription;
-import org.bricolages.streaming.ConfigError;
+import org.bricolages.streaming.exception.*;
+import java.util.ArrayList;
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;

--- a/src/main/java/org/bricolages/streaming/s3/S3Agent.java
+++ b/src/main/java/org/bricolages/streaming/s3/S3Agent.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.s3;
-import org.bricolages.streaming.ApplicationAbort;
+import org.bricolages.streaming.exception.ApplicationAbort;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;

--- a/src/main/java/org/bricolages/streaming/s3/S3IOException.java
+++ b/src/main/java/org/bricolages/streaming/s3/S3IOException.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.s3;
-import org.bricolages.streaming.ApplicationException;
+import org.bricolages.streaming.exception.ApplicationException;
 
 public class S3IOException extends ApplicationException {
     S3IOException(String message) {

--- a/src/main/java/org/bricolages/streaming/s3/S3UrlParseException.java
+++ b/src/main/java/org/bricolages/streaming/s3/S3UrlParseException.java
@@ -1,5 +1,5 @@
 package org.bricolages.streaming.s3;
-import org.bricolages.streaming.ApplicationException;
+import org.bricolages.streaming.exception.ApplicationException;
 
 public class S3UrlParseException extends ApplicationException {
     S3UrlParseException(String message) {

--- a/src/main/java/org/bricolages/streaming/stream/DataPacketRouter.java
+++ b/src/main/java/org/bricolages/streaming/stream/DataPacketRouter.java
@@ -1,11 +1,7 @@
-package org.bricolages.streaming.s3;
-import org.bricolages.streaming.ApplicationError;
-import org.bricolages.streaming.ConfigError;
-import org.bricolages.streaming.SourceLocator;
-import org.bricolages.streaming.DataStream;
-import org.bricolages.streaming.DataStreamRepository;
-import org.bricolages.streaming.StreamBundle;
-import org.bricolages.streaming.StreamBundleRepository;
+package org.bricolages.streaming.stream;
+import org.bricolages.streaming.locator.*;
+import org.bricolages.streaming.s3.*;
+import org.bricolages.streaming.exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.nio.file.Paths;
 import java.util.Objects;
@@ -19,7 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @RequiredArgsConstructor
 @Slf4j
-public class ObjectMapper {
+public class DataPacketRouter {
     final List<Entry> entries;
 
     void check() throws ConfigError {

--- a/src/main/java/org/bricolages/streaming/stream/DataStream.java
+++ b/src/main/java/org/bricolages/streaming/stream/DataStream.java
@@ -1,5 +1,4 @@
-package org.bricolages.streaming;
-
+package org.bricolages.streaming.stream;
 import java.sql.Timestamp;
 import java.util.List;
 import javax.persistence.*;

--- a/src/main/java/org/bricolages/streaming/stream/DataStreamRepository.java
+++ b/src/main/java/org/bricolages/streaming/stream/DataStreamRepository.java
@@ -1,4 +1,5 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.stream;
+import org.bricolages.streaming.exception.*;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import lombok.*;

--- a/src/main/java/org/bricolages/streaming/stream/StreamBundle.java
+++ b/src/main/java/org/bricolages/streaming/stream/StreamBundle.java
@@ -1,4 +1,4 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.stream;
 import javax.persistence.*;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/org/bricolages/streaming/stream/StreamBundleRepository.java
+++ b/src/main/java/org/bricolages/streaming/stream/StreamBundleRepository.java
@@ -1,4 +1,5 @@
-package org.bricolages.streaming;
+package org.bricolages.streaming.stream;
+import org.bricolages.streaming.exception.*;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import lombok.*;

--- a/src/test/java/org/bricolages/streaming/filter/SequenceOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/SequenceOpTest.java
@@ -1,6 +1,6 @@
 package org.bricolages.streaming.filter;
 import org.junit.Test;
-import org.bricolages.streaming.ApplicationError;
+import org.bricolages.streaming.exception.ApplicationError;
 import static org.junit.Assert.*;
 import lombok.*;
 

--- a/src/test/java/org/bricolages/streaming/stream/DataPacketRouterTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/DataPacketRouterTest.java
@@ -1,5 +1,7 @@
-package org.bricolages.streaming.s3;
-import org.bricolages.streaming.*;
+package org.bricolages.streaming.stream;
+import org.bricolages.streaming.locator.*;
+import org.bricolages.streaming.s3.*;
+import org.bricolages.streaming.exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.*;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -11,16 +13,16 @@ import lombok.*;
 
 @DataJpaTest
 @RunWith(SpringJUnit4ClassRunner.class)
-public class ObjectMapperTest {
-    ObjectMapper newRouter(ObjectMapper.Entry... entries) {
-        val router = new ObjectMapper(Arrays.asList(entries));
+public class DataPacketRouterTest {
+    DataPacketRouter newRouter(DataPacketRouter.Entry... entries) {
+        val router = new DataPacketRouter(Arrays.asList(entries));
         router.streamRepos = streamRepos;
         router.streamBundleRepos = bundleRepos;
         return router;
     }
 
-    ObjectMapper.Entry entry(String srcUrlPattern, String streamName, String streamPrefix, String destBucket, String destPrefix, String objectPrefix, String objectName) {
-        return new ObjectMapper.Entry(srcUrlPattern, streamName, streamPrefix, destBucket, destPrefix, objectPrefix, objectName);
+    DataPacketRouter.Entry entry(String srcUrlPattern, String streamName, String streamPrefix, String destBucket, String destPrefix, String objectPrefix, String objectName) {
+        return new DataPacketRouter.Entry(srcUrlPattern, streamName, streamPrefix, destBucket, destPrefix, objectPrefix, objectName);
     }
 
     S3ObjectLocation loc(String url) throws S3UrlParseException {


### PR DESCRIPTION
- streamパッケージを導入してstream関係のクラスを集約
- locatorパッケージを導入
- exceptionパッケージを導入して、アプリ全体で使われる例外クラスを集約
- rename class: ObjectMapper → DataPacketRouter

S3オブジェクト（ログファイル）をpacket、packetの転送制御をrouting、packetを加工するfilterのまとまりの単位をstream、とそれぞれ定義する。

FYI @bricolages/all 