### PR TITLE
Support sub-seconds timestamps

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/FloatOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/FloatOp.java
@@ -15,7 +15,7 @@ public class FloatOp extends SingleColumnOp {
     @Override
     public Object applyValue(Object rawValue, Record record) throws FilterException {
         if (rawValue == null) return null;
-        float value = getFloat(rawValue);
+        float value = (float)getFloat(rawValue);
         // getFloat returns Inf/-Inf for too big/small value
         if (Float.isInfinite(value) || Float.isNaN(value)) return null;
         return Float.valueOf(value);

--- a/src/main/java/org/bricolages/streaming/filter/Op.java
+++ b/src/main/java/org/bricolages/streaming/filter/Op.java
@@ -45,26 +45,49 @@ public abstract class Op {
         }
     }
 
-    protected float getFloat(Object value) throws FilterException {
-        if (value instanceof Integer) {
-            return ((Integer)value).floatValue();
+    // Returns true if value is a float.
+    // If it seems integers, this method returns false.
+    protected boolean isFloat(Object value) {
+        if (value instanceof Double) {
+            return true;
         }
-        else if (value instanceof Long) {
-            return ((Long)value).floatValue();
+        else if (value instanceof Float) {
+            return true;
         }
         else if (value instanceof String) {
             try {
-                return Float.valueOf((String)value);
+                Double.valueOf((String)value);
+                return true;
+            }
+            catch (NumberFormatException ex) {
+                return false;
+            }
+        }
+        else {
+            return false;
+        }
+    }
+
+    protected double getFloat(Object value) throws FilterException {
+        if (value instanceof Integer) {
+            return ((Integer)value).doubleValue();
+        }
+        else if (value instanceof Long) {
+            return ((Long)value).doubleValue();
+        }
+        else if (value instanceof String) {
+            try {
+                return Double.valueOf((String)value);
             }
             catch (NumberFormatException ex) {
                 throw new FilterException(ex);
             }
         }
         else if (value instanceof Float) {
-            return ((Float)value).floatValue();
+            return ((Float)value).doubleValue();
         }
         else if (value instanceof Double) {
-            return ((Double)value).floatValue();
+            return ((Double)value).doubleValue();
         }
         else {
             throw new FilterException("unexpected value for integer");
@@ -74,6 +97,15 @@ public abstract class Op {
     protected OffsetDateTime unixTimeToOffsetDateTime(long t, ZoneOffset offset) throws FilterException {
         try {
             return Instant.ofEpochSecond(t).atOffset(offset);
+        }
+        catch (DateTimeException ex) {
+            throw new FilterException(ex);
+        }
+    }
+
+    protected OffsetDateTime unixTimeToOffsetDateTime(double t, ZoneOffset offset) throws FilterException {
+        try {
+            return Instant.ofEpochMilli((long)(t * 1000)).atOffset(offset);
         }
         catch (DateTimeException ex) {
             throw new FilterException(ex);

--- a/src/main/java/org/bricolages/streaming/filter/UnixTimeOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/UnixTimeOp.java
@@ -29,6 +29,11 @@ public class UnixTimeOp extends SingleColumnOp {
     @Override
     public Object applyValue(Object value, Record record) throws FilterException {
         if (value == null) return null;
-        return formatSqlTimestamp(unixTimeToOffsetDateTime(getInteger(value), zoneOffset));
+        if (isFloat(value)) {
+            return formatSqlTimestamp(unixTimeToOffsetDateTime(getFloat(value), zoneOffset));
+        }
+        else {
+            return formatSqlTimestamp(unixTimeToOffsetDateTime(getInteger(value), zoneOffset));
+        }
     }
 }

--- a/src/test/java/org/bricolages/streaming/filter/TimeZoneOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/TimeZoneOpTest.java
@@ -23,6 +23,12 @@ public class TimeZoneOpTest {
         assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01T10:41:06+00:00", null));
         assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01 10:41:06 +0000", null));
         assertEquals("2016-07-01T19:41:06+09:00", f.applyValue("2016-07-01 10:41:06 UTC", null));
+
+        // with fractional seconds
+        assertEquals("2016-07-01T19:41:06.246+09:00", f.applyValue("2016-07-01T10:41:06.246Z", null));
+        assertEquals("2016-07-01T19:41:06.246+09:00", f.applyValue("2016-07-01T10:41:06.246+00:00", null));
+        assertEquals("2016-07-01T19:41:06.246+09:00", f.applyValue("2016-07-01 10:41:06.246 +0000", null));
+        assertEquals("2016-07-01T19:41:06.246+09:00", f.applyValue("2016-07-01 10:41:06.246 UTC", null));
     }
 
     @Test

--- a/src/test/java/org/bricolages/streaming/filter/UnixTimeOpTest.java
+++ b/src/test/java/org/bricolages/streaming/filter/UnixTimeOpTest.java
@@ -21,6 +21,9 @@ public class UnixTimeOpTest {
         assertEquals("2016-07-01T16:41:06+09:00", f.applyValue(1467358866, null));
         assertEquals("2016-07-01T16:41:06+09:00", f.applyValue("1467358866", null));
         assertEquals("2016-07-01T16:41:06+09:00", f.applyValue(Double.valueOf(1467358866), null));
+
+        assertEquals("2016-07-01T16:41:06.246+09:00", f.applyValue(Double.valueOf(1467358866.246D), null));
+        assertEquals("2016-07-01T16:41:06.246+09:00", f.applyValue("1467358866.246", null));
     }
 
     @Test(expected = FilterException.class)


### PR DESCRIPTION
TimeZoneOpとUnixTimeOpがマイクロ秒（1/1000秒）を受け付けるようにします。

TimeZoneOpの場合は `2017-12-05T13:45:53.235Z` のような文字列を受け付け、UnixTimeOpの場合は `1467358866.246D` などのdouble値を受け付けます。floatだと精度足りなくて死んじゃうので注意。

FYI @KOBA789 @shimpeko @inohiro 