### PR TITLE
fix: Catches & wraps all IOException and UncheckedIOException as LocatorIOException

### DIFF
--- a/src/main/java/org/bricolages/streaming/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/Preprocessor.java
@@ -7,7 +7,6 @@ import org.bricolages.streaming.exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.IOException;
 import java.util.Objects;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
@@ -19,7 +18,7 @@ public class Preprocessor implements EventHandlers {
     final LogQueue logQueue;
     final DataPacketRouter router;
 
-    public void run() throws IOException {
+    public void run() {
         log.info("server started");
         trapSignals();
         try {
@@ -67,7 +66,7 @@ public class Preprocessor implements EventHandlers {
             log.debug("src: {}, dest: {}, in: {}, out: {}", src.toString(), route.getDestLocator().toString(), result.inputRows, result.outputRows);
             return true;
         }
-        catch (IOException | LocatorIOException ex) {
+        catch (LocatorIOException ex) {
             log.error("src: {}, error: {}", src.toString(), ex.getMessage());
             return false;
         }
@@ -220,7 +219,7 @@ public class Preprocessor implements EventHandlers {
 
             eventQueue.deleteAsync(event);
         }
-        catch (LocatorIOException | IOException | ConfigError ex) {
+        catch (LocatorIOException | ConfigError ex) {
             log.error("src: {}, error: {}", src.toString(), ex.getMessage());
             result.failed(ex.getMessage());
             logRepos.save(result);

--- a/src/main/java/org/bricolages/streaming/filter/ObjectFilter.java
+++ b/src/main/java/org/bricolages/streaming/filter/ObjectFilter.java
@@ -2,6 +2,7 @@ package org.bricolages.streaming.filter;
 import org.bricolages.streaming.locator.*;
 import java.util.List;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.PrintWriter;
@@ -14,41 +15,62 @@ public class ObjectFilter {
     final LocatorIOManager ioManager;
     final List<Op> operators;
 
-    public S3ObjectMetadata processLocator(S3ObjectLocator src, S3ObjectLocator dest, FilterResult result, String sourceName) throws LocatorIOException, IOException {
-        try (LocatorIOManager.Buffer buf = ioManager.openWriteBuffer(dest, sourceName)) {
-            try (BufferedReader r = ioManager.openBufferedReader(src)) {
-                processStream(r, buf.getBufferedWriter(), result, sourceName);
-            }
-            return buf.commit();
-        }
-    }
-
-
-    public FilterResult processLocatorAndPrint(S3ObjectLocator src, BufferedWriter out) throws LocatorIOException, IOException {
-        val result = new FilterResult(src.toString(), null);
-        try (BufferedReader r = ioManager.openBufferedReader(src)) {
-            processStream(r, out, result, src.toString());
-        }
-        return result;
-    }
-
-    public void processStream(BufferedReader r, BufferedWriter w, FilterResult result, String sourceName) throws IOException {
-        final PrintWriter out = new PrintWriter(w);
-        r.lines().forEach((line) -> {
-            if (line.trim().isEmpty()) return;  // should not count blank line
-            result.inputRows++;
-            try {
-                String outStr = processRecord(line);
-                if (outStr != null) {
-                    out.println(outStr);
-                    result.outputRows++;
+    public S3ObjectMetadata processLocator(S3ObjectLocator src, S3ObjectLocator dest, FilterResult result, String sourceName) throws LocatorIOException {
+        try {
+            try (LocatorIOManager.Buffer buf = ioManager.openWriteBuffer(dest, sourceName)) {
+                try (BufferedReader r = ioManager.openBufferedReader(src)) {
+                    processStream(r, buf.getBufferedWriter(), result, sourceName);
                 }
+                return buf.commit();
             }
-            catch (JSONException ex) {
-                log.debug("JSON parse error: {}:{}: {}", sourceName, result.inputRows, ex.getMessage());
-                result.errorRows++;
+        }
+        catch (UncheckedIOException ex) {
+            throw new LocatorIOException(ex.getCause());
+        }
+        catch (IOException ex) {
+            throw new LocatorIOException(ex);
+        }
+    }
+
+
+    public FilterResult processLocatorAndPrint(S3ObjectLocator src, BufferedWriter out) throws LocatorIOException {
+        try {
+            val result = new FilterResult(src.toString(), null);
+            try (BufferedReader r = ioManager.openBufferedReader(src)) {
+                processStream(r, out, result, src.toString());
             }
-        });
+            return result;
+        }
+        catch (UncheckedIOException ex) {
+            throw new LocatorIOException(ex.getCause());
+        }
+        catch (IOException ex) {
+            throw new LocatorIOException(ex);
+        }
+    }
+
+    public void processStream(BufferedReader r, BufferedWriter w, FilterResult result, String sourceName) throws LocatorIOException {
+        try {
+            final PrintWriter out = new PrintWriter(w);
+            r.lines().forEach((line) -> {
+                if (line.trim().isEmpty()) return;  // should not count blank line
+                result.inputRows++;
+                try {
+                    String outStr = processRecord(line);
+                    if (outStr != null) {
+                        out.println(outStr);
+                        result.outputRows++;
+                    }
+                }
+                catch (JSONException ex) {
+                    log.debug("JSON parse error: {}:{}: {}", sourceName, result.inputRows, ex.getMessage());
+                    result.errorRows++;
+                }
+            });
+        }
+        catch (UncheckedIOException ex) {
+            throw new LocatorIOException(ex.getCause());
+        }
     }
 
     public String processRecord(String json) throws JSONException {

--- a/src/main/java/org/bricolages/streaming/locator/LocatorIOException.java
+++ b/src/main/java/org/bricolages/streaming/locator/LocatorIOException.java
@@ -2,11 +2,11 @@ package org.bricolages.streaming.locator;
 import org.bricolages.streaming.exception.ApplicationException;
 
 public class LocatorIOException extends ApplicationException {
-    LocatorIOException(String message) {
+    public LocatorIOException(String message) {
         super(message);
     }
 
-    LocatorIOException(Exception cause) {
+    public LocatorIOException(Exception cause) {
         super(cause);
     }
 }

--- a/src/main/java/org/bricolages/streaming/locator/LocatorIOManager.java
+++ b/src/main/java/org/bricolages/streaming/locator/LocatorIOManager.java
@@ -14,6 +14,7 @@ import java.io.OutputStreamWriter;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import java.nio.file.Path;
@@ -40,7 +41,7 @@ public class LocatorIOManager {
                 Files.copy(in, dest);
             }
         }
-        catch (IOException ex) {
+        catch (UncheckedIOException | IOException ex) {
             throw new LocatorIOException("I/O error: " + ex.getMessage());
         }
     }
@@ -66,7 +67,7 @@ public class LocatorIOManager {
                 return in;
             }
         }
-        catch (IOException ex) {
+        catch (UncheckedIOException | IOException ex) {
             throw new LocatorIOException("I/O error: " + ex.getMessage());
         }
     }
@@ -144,7 +145,7 @@ public class LocatorIOManager {
                 OutputStream out = dest.isGzip() ? new GZIPOutputStream(s) : s;
                 this.bufferedWriter = new BufferedWriter(new OutputStreamWriter(out, DATA_FILE_CHARSET));
             }
-            catch (IOException ex) {
+            catch (UncheckedIOException | IOException ex) {
                 throw new LocatorIOException("I/O error: " + ex.getMessage());
             }
         }
@@ -155,7 +156,7 @@ public class LocatorIOManager {
                 val result = upload(path, dest);
                 return new S3ObjectMetadata(dest, Instant.now(), Files.size(path), result.getETag());
             }
-            catch (IOException ex) {
+            catch (UncheckedIOException | IOException ex) {
                 throw new LocatorIOException("I/O error: " + ex.getMessage());
             }
         }
@@ -165,13 +166,13 @@ public class LocatorIOManager {
             try {
                 bufferedWriter.close();
             }
-            catch (IOException ex) {
+            catch (UncheckedIOException | IOException ex) {
                 // ignore
             }
             try {
                 Files.deleteIfExists(path);
             }
-            catch (IOException ex) {
+            catch (UncheckedIOException | IOException ex) {
                 log.error("could not remove temporary file: {}", ex);
             }
         }

--- a/src/main/java/org/bricolages/streaming/stream/BoundStream.java
+++ b/src/main/java/org/bricolages/streaming/stream/BoundStream.java
@@ -3,7 +3,6 @@ import org.bricolages.streaming.filter.*;
 import org.bricolages.streaming.locator.*;
 import org.bricolages.streaming.exception.*;
 import java.nio.file.Paths;
-import java.io.IOException;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -55,7 +54,7 @@ public class BoundStream {
         return filterFactory.load(stream);
     }
 
-    public S3ObjectMetadata processLocator(S3ObjectLocator src, S3ObjectLocator dest, FilterResult result) throws LocatorIOException, IOException, ConfigError {
+    public S3ObjectMetadata processLocator(S3ObjectLocator src, S3ObjectLocator dest, FilterResult result) throws LocatorIOException, ConfigError {
         return loadFilter().processLocator(src, dest, result, stream.getStreamName());
     }
 }


### PR DESCRIPTION
拾いそこねているUncheckedIOExcpetionがあったのでLocatorIOExceptionにラップします。ついでに、なぜか別立てだったIOExceptionもラップ。