### PR TITLE
fix: SequenceOp: Handles the case more than 10000 sequence is required

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
@@ -28,10 +28,10 @@ public class SequenceOp extends SingleColumnOp {
     SequenceOp(OperatorDefinition def, SequencialNumberAllocator repo) {
         super(def);
         this.seqRepo = repo;
-        fetchSeq();
+        allocateSequenceBlock();
     }
 
-    void fetchSeq() {
+    void allocateSequenceBlock() {
         val seq = seqRepo.allocate();
         this.currentValue = seq.getLastValue();
         this.upperValue = seq.getNextValue();
@@ -44,7 +44,7 @@ public class SequenceOp extends SingleColumnOp {
 
         // We can use the last value of the block (e.g. 2000)
         if (currentValue > upperValue) {
-            fetchSeq();
+            allocateSequenceBlock();
             // Do not use the first number of the block (e.g. 2000)
             currentValue ++;
         }

--- a/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequenceOp.java
@@ -5,30 +5,51 @@ import lombok.*;
 public class SequenceOp extends SingleColumnOp {
     static final void register(OpBuilder builder) {
         builder.registerOperator("sequence", (def) ->
-            new SequenceOp(def, builder.sequencialNumberRepository)
+            new SequenceOp(def, new SequencialNumberAllocatorImpl(builder.sequencialNumberRepository))
         );
     }
 
+    static class SequencialNumberAllocatorImpl implements SequencialNumberAllocator {
+        final SequencialNumberRepository repos;
+
+        SequencialNumberAllocatorImpl(SequencialNumberRepository repos) {
+            this.repos = repos;
+        }
+
+        public SequencialNumber allocate() {
+            return this.repos.allocate();
+        }
+    }
+
+    final SequencialNumberAllocator seqRepo;
     long currentValue;
     long upperValue;
 
-    SequenceOp(OperatorDefinition def) {
+    SequenceOp(OperatorDefinition def, SequencialNumberAllocator repo) {
         super(def);
+        this.seqRepo = repo;
+        fetchSeq();
     }
 
-    SequenceOp(OperatorDefinition def, SequencialNumberRepository repo) {
-        this(def);
-        val seq = repo.allocate();
+    void fetchSeq() {
+        val seq = seqRepo.allocate();
         this.currentValue = seq.getLastValue();
         this.upperValue = seq.getNextValue();
     }
 
     private long getNextValue() {
+        // We get a sequence block like [current=1000, upper=2000].
+        // We should use 1001-2000 for that block, so increment currentValue first.
         currentValue ++;
+
+        // We can use the last value of the block (e.g. 2000)
         if (currentValue > upperValue) {
-            throw new ApplicationError("sequence number is starved");
+            fetchSeq();
+            // Do not use the first number of the block (e.g. 2000)
+            currentValue ++;
         }
-        return currentValue;
+
+        return this.currentValue;
     }
 
     @Override

--- a/src/main/java/org/bricolages/streaming/filter/SequencialNumber.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequencialNumber.java
@@ -4,6 +4,7 @@ import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor
+@AllArgsConstructor
 @Slf4j
 @Entity
 @Table(name="strload_sequence")

--- a/src/main/java/org/bricolages/streaming/filter/SequencialNumberAllocator.java
+++ b/src/main/java/org/bricolages/streaming/filter/SequencialNumberAllocator.java
@@ -1,0 +1,6 @@
+package org.bricolages.streaming.filter;
+import lombok.*;
+
+public interface SequencialNumberAllocator {
+    SequencialNumber allocate();
+}


### PR DESCRIPTION
1オブジェクト中でシーケンスが足りなくなった場合に、次のシーケンスブロックをDBから取得するようにします。

このopは #24 で導入されているのだが、なんで最初からこうなっていないのか誰も思い出せなかった。

@KOBA789 レビューお願いします。