### PR TITLE
date column accepts timestamp strings

### DIFF
--- a/src/main/java/org/bricolages/streaming/filter/Cleanse.java
+++ b/src/main/java/org/bricolages/streaming/filter/Cleanse.java
@@ -309,6 +309,10 @@ public final class Cleanse {
     }
 
     static public LocalDate getLocalDate(Object value) throws FilterException {
+        return getLocalDate(value, ZoneOffset.UTC, null);
+    }
+
+    static public LocalDate getLocalDate(Object value, ZoneOffset defaultOffset, ZoneOffset targetOffset) throws FilterException {
         if (! (value instanceof String)) {
             throw new FilterException("is not a string");
         }
@@ -317,7 +321,8 @@ public final class Cleanse {
             return LocalDate.parse(str, DateTimeFormatter.ISO_DATE);
         }
         catch (DateTimeException e) {
-            throw new FilterException("could not parse a date: " + str);
+            val dt = getOffsetDateTime(str, defaultOffset, true);
+            return (targetOffset != null ? dt.withOffsetSameInstant(targetOffset) : dt).toLocalDate();
         }
     }
 }

--- a/src/main/java/org/bricolages/streaming/stream/processor/DateColumnProcessor.java
+++ b/src/main/java/org/bricolages/streaming/stream/processor/DateColumnProcessor.java
@@ -1,20 +1,41 @@
 package org.bricolages.streaming.stream.processor;
 import org.bricolages.streaming.stream.StreamColumn;
 import org.bricolages.streaming.filter.*;
+import org.bricolages.streaming.exception.*;
+import java.time.ZoneOffset;
+import java.time.OffsetDateTime;
+import java.time.DateTimeException;
 import lombok.*;
 
 public class DateColumnProcessor extends SingleColumnProcessor {
     static DateColumnProcessor build(StreamColumn column, ProcessorContext ctx) {
-        return new DateColumnProcessor(column);
+        try {
+            val src = (column.getSourceOffset() != null ? ZoneOffset.of(column.getSourceOffset()) : ZoneOffset.UTC);
+            val dest = (column.getZoneOffset() != null) ? ZoneOffset.of(column.getZoneOffset()) : null;
+            return new DateColumnProcessor(column, src, dest);
+        }
+        catch (DateTimeException ex) {
+            throw new ConfigError("bad zone offset: " + column.getName() + ": " + ex.getMessage());
+        }
     }
 
-    public DateColumnProcessor(StreamColumn column) {
+    final ZoneOffset sourceOffset;
+    final ZoneOffset zoneOffset;
+
+    public DateColumnProcessor(StreamColumn column, ZoneOffset sourceOffset, ZoneOffset zoneOffset) {
         super(column);
+        this.sourceOffset = sourceOffset;
+        this.zoneOffset = zoneOffset;
+    }
+
+    // For tests
+    DateColumnProcessor(StreamColumn column, String src, String dest) {
+        this(column, (src != null ? ZoneOffset.of(src) : ZoneOffset.UTC), (dest != null ? ZoneOffset.of(dest) : null));
     }
 
     @Override
     public Object processValue(Object value) throws FilterException {
         if (value == null) return null;
-        return Cleanse.formatSqlDate(Cleanse.getLocalDate(value));
+        return Cleanse.formatSqlDate(Cleanse.getLocalDate(value, sourceOffset, zoneOffset));
     }
 }

--- a/src/test/java/org/bricolages/streaming/stream/processor/DateColumnProcessorTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/processor/DateColumnProcessorTest.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 public class DateColumnProcessorTest {
     DateColumnProcessor defaultProcessor() {
-        return new DateColumnProcessor(StreamColumn.forName("x"));
+        return new DateColumnProcessor(StreamColumn.forName("x"), "+00:00", null);
     }
 
     @Test
@@ -15,6 +15,22 @@ public class DateColumnProcessorTest {
         val proc = defaultProcessor();
         assertNull(proc.processValue(null));
         assertEquals("2018-01-23", proc.processValue("2018-01-23"));
+    }
+
+    @Test
+    public void process_timestamp() throws Exception {
+        val proc = defaultProcessor();
+        assertEquals("2018-01-23", proc.processValue("2018-01-23 12:00:00"));
+        assertEquals("2018-01-23", proc.processValue("2018-01-23T03:00:00+00:00"));
+        assertEquals("2018-01-23", proc.processValue("2018-01-23T03:00:00+09:00"));
+    }
+
+    @Test
+    public void process_timestamp_tz() throws Exception {
+        val proc = new DateColumnProcessor(StreamColumn.forName("x"), "+00:00", "+09:00");
+        assertEquals("2018-01-24", proc.processValue("2018-01-23 23:00:00"));
+        assertEquals("2018-01-24", proc.processValue("2018-01-23T23:00:00+00:00"));
+        assertEquals("2018-01-23", proc.processValue("2018-01-23T23:00:00+09:00"));
     }
 
     @Test(expected = FilterException.class)


### PR DESCRIPTION
date型カラムに対してtimestampが送られてくる場合があり、受け入れてまずいこともないので許可します。timestampと同じくタイムゾーンの変換も可能。