### PR TITLE
fix: preflight: Allows partition_source property for timestamp domains

### DIFF
--- a/src/main/java/org/bricolages/streaming/preflight/domains/TimestampDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/TimestampDomain.java
@@ -22,6 +22,8 @@ public class TimestampDomain extends PrimitiveDomain {
     @Getter private final String type = "timestamp";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
+    @Getter private final boolean partitionSource = false;
+
     // This is necessary to accept empty value
     @JsonCreator public TimestampDomain(String nil) { /* noop */ }
 

--- a/src/main/java/org/bricolages/streaming/preflight/domains/TimestamptzDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/TimestamptzDomain.java
@@ -22,6 +22,8 @@ public class TimestamptzDomain extends PrimitiveDomain {
     @Getter private final String type = "timestamptz";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
+    @Getter private final boolean partitionSource = false;
+
     // This is necessary to accept empty value
     @JsonCreator public TimestamptzDomain(String nil) { /* noop */ }
 


### PR DESCRIPTION
preflightの処理には影響しないので、partition_sourceを受け付けて捨てるだけにします。

@KOBA789 