### PR TITLE
fix: SequencialNumber never uses generated value, do not use @GeneratedValue

### DIFF
--- a/src/main/java/org/bricolages/streaming/stream/op/SequencialNumber.java
+++ b/src/main/java/org/bricolages/streaming/stream/op/SequencialNumber.java
@@ -14,7 +14,6 @@ public class SequencialNumber {
     long lastValue;
 
     @Id
-    @GeneratedValue
     @Column(name="nextval")
     @Getter
     long nextValue;


### PR DESCRIPTION
`@GeneratedValue` を使っているとデフォルトのgeneratorがobsoleteになってて、Hibernateが警告出すので消します。nextValueカラムは常にnextvalによって生成されるので、特にHibernate側で特別扱いをする必要はないはず。

@KOBA789 おねがいします