### PR TITLE
fix: We cannot get last_value and nextval atomically, use only nextval

### DIFF
--- a/src/main/java/org/bricolages/streaming/Application.java
+++ b/src/main/java/org/bricolages/streaming/Application.java
@@ -234,7 +234,10 @@ public class Application {
         System.err.println("");
         System.err.println("*** TEST ***");
 
-        // test code here
+        for (int i = 0; i < 3; i++) {
+            val num = sequentialNumberRepository.allocate();
+            System.err.println("next=" + num.getNextValue() + ", last=" + num.getLastValue());
+        }
 
         System.err.println("OK");
         System.err.println("");

--- a/src/main/java/org/bricolages/streaming/stream/op/SequencialNumber.java
+++ b/src/main/java/org/bricolages/streaming/stream/op/SequencialNumber.java
@@ -17,4 +17,13 @@ public class SequencialNumber {
     @Column(name="nextval")
     @Getter
     long nextValue;
+
+    // This depends on sequence object definition, but we cannot get
+    // nextval and last_value at the same time (atomically).
+    // So we use constant here as the second best.
+    static final long BATCH_SIZE = 10000;
+
+    void setLastValueFromNextValue() {
+        this.lastValue = nextValue - BATCH_SIZE;
+    }
 }

--- a/src/main/java/org/bricolages/streaming/stream/op/SequencialNumberRepository.java
+++ b/src/main/java/org/bricolages/streaming/stream/op/SequencialNumberRepository.java
@@ -4,6 +4,13 @@ import org.springframework.data.jpa.repository.Query;
 import lombok.*;
 
 public interface SequencialNumberRepository extends JpaRepository<SequencialNumber, Long> {
-    @Query(value = "select last_value, nextval('strload_sequence') from strload_sequence", nativeQuery = true)
-    SequencialNumber allocate();
+    // CLUDGE: provide dummy last_value to fill all fields
+    @Query(value = "select nextval('strload_sequence'), -1 as last_value", nativeQuery = true)
+    SequencialNumber _allocateNext();
+
+    default SequencialNumber allocate() {
+        val num = _allocateNext();
+        num.setLastValueFromNextValue();
+        return num;
+    }
 }


### PR DESCRIPTION
sequenceがごくまれに重複する問題の修正（のつもりだが自信はない）。

`select last_value, nextval('strload_sequence') from strload_sequence` がatomicに実行されず、last_valueが古くなる場合があるのではないか。別の言い方をすると、last_valueを取得してからnextvalを取得するまでの間に別のnextvalが実行されてしまう場合があるのではないか。
