### PR TITLE
Discard preproc messages for uninitialized streams

### DIFF
--- a/src/main/java/org/bricolages/streaming/preproc/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/preproc/Preprocessor.java
@@ -207,7 +207,12 @@ public class Preprocessor implements EventHandlers {
 
         streamDetected(msg, stream);
         val dest = stream.getDestLocator();
-        if (stream.doesDefer()) {
+        if (stream.isNotInitialized()) {
+            log.info("discard event for uninitialized stream: {}", event.getLocator().toString());
+            deleteMessage(msg, event);
+            return;
+        }
+        if (stream.isDisabled()) {
             // Processing is temporary disabled; process objects later
             return;
         }

--- a/src/main/java/org/bricolages/streaming/stream/BoundStream.java
+++ b/src/main/java/org/bricolages/streaming/stream/BoundStream.java
@@ -43,8 +43,12 @@ public class BoundStream {
         return stream.getTableId();
     }
 
-    public boolean doesDefer() {
-        return stream.doesDefer();
+    public boolean isNotInitialized() {
+        return stream.isNotInitialized();
+    }
+
+    public boolean isDisabled() {
+        return stream.isDisabled();
     }
 
     public boolean doesDiscard() {

--- a/src/main/java/org/bricolages/streaming/stream/PacketStream.java
+++ b/src/main/java/org/bricolages/streaming/stream/PacketStream.java
@@ -61,8 +61,12 @@ public class PacketStream {
         return this.no_dispatch;
     }
 
-    public boolean doesDefer() {
-        return this.disabled || !this.initialized;
+    public boolean isNotInitialized() {
+        return !this.initialized;
+    }
+
+    public boolean isDisabled() {
+        return this.disabled;
     }
 
     public PacketStream(String streamName) {


### PR DESCRIPTION
未初期化のストリームに対するpreprocメッセージはSQSキューに滞留させるのではなく、即座に削除するように変更します。

この変更を導入した場合、ログを初期化したあとに必ず過去分のpreprocイベントを手動で詰める必要があります。

@bricolages/all おねがいします