### PR TITLE
fix: table may not exist for the stream, check stream status first

### DIFF
--- a/src/main/java/org/bricolages/streaming/preproc/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/preproc/Preprocessor.java
@@ -207,7 +207,6 @@ public class Preprocessor implements EventHandlers {
         }
 
         streamDetected(msg, route.getStream());
-        val dest = route.getDestLocator();
         if (route.isNotInitialized()) {
             log.info("discard event for uninitialized stream: {}", event.getLocator().toString());
             deleteMessage(msg, event);
@@ -220,6 +219,13 @@ public class Preprocessor implements EventHandlers {
         if (route.doesDiscard()) {
             // Just ignore without processing, do not keep SQS messages.
             log.info("discard event: {}", event.getLocator().toString());
+            deleteMessage(msg, event);
+            return;
+        }
+
+        val dest = route.getDestLocator();
+        if (dest == null) {
+            log.warn("missing dest object location: stream={}", route.getStreamName());
             deleteMessage(msg, event);
             return;
         }

--- a/src/main/java/org/bricolages/streaming/stream/Route.java
+++ b/src/main/java/org/bricolages/streaming/stream/Route.java
@@ -75,8 +75,8 @@ public class Route {
 
     public S3ObjectLocator getDestLocator() {
         if (stream == null) return null;
-        if (bundle == null) return null;
         val table = stream.getTable();
+        if (table == null) return null;
         return new S3ObjectLocator(table.getBucket(), Paths.get(table.getPrefix(), objectPrefix, objectName).toString());
     }
 


### PR DESCRIPTION
disableのストリームやblackholeのストリームにはtableが紐付いていない場合があるので、ステータスを先にチェックする