### PR TITLE
[preflight][fix] could not intern type name: float

### DIFF
--- a/src/main/java/org/bricolages/streaming/preflight/domains/DoubleDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/DoubleDomain.java
@@ -9,7 +9,7 @@ import lombok.*;
 @JsonTypeName("double")
 @MultilineDescription("64bit floating point number")
 public class DoubleDomain extends PrimitiveDomain {
-    @Getter private final String type = "float";
+    @Getter private final String type = "double";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
     // This is necessary to accept null value


### PR DESCRIPTION
When .strdef file has column(s) with `double` domain
preflight command fails with following error.

```
preflight: error: temperature column: could not intern type name: float
```