### PR TITLE
Configure Sentry stacktrace.app.packages

### DIFF
--- a/src/main/resources/sentry.properties
+++ b/src/main/resources/sentry.properties
@@ -1,0 +1,1 @@
+stacktrace.app.packages=org.bricolages


### PR DESCRIPTION
Sentry cilentのバージョンを上げたあと、設定をしろという警告が出ているので設定する。