### PR TITLE
fix: Handles too big Unix time seconds as milliseconds

### DIFF
--- a/src/main/java/org/bricolages/streaming/stream/processor/Cleanse.java
+++ b/src/main/java/org/bricolages/streaming/stream/processor/Cleanse.java
@@ -159,11 +159,22 @@ public final class Cleanse {
         }
     }
 
+    // This is 49503-02-10T02:40:00Z if we assume it is an epoch seconds,
+    // but is 2017-07-14T02:40:00Z if we assume it is an epoch milliseconds.
+    // It must be milliseconds.
+    static final long TOO_BIG_EPOCH_SECONDS = 1500000000000L;
+    static final double TOO_BIG_EPOCH_SECONDS_D = 1500000000000.0D;
+
     static public OffsetDateTime unixTimeToOffsetDateTime(long t, ZoneOffset offset, TimeUnit unit) throws CleanseException {
         try {
             switch (unit) {
-            case SECONDS:
-                return Instant.ofEpochSecond(t).atOffset(offset);
+            case SECONDS:   // default
+                if (t > TOO_BIG_EPOCH_SECONDS) {
+                    return Instant.ofEpochMilli(t).atOffset(offset);
+                }
+                else {
+                    return Instant.ofEpochSecond(t).atOffset(offset);
+                }
             case MILLISECONDS:
                 return Instant.ofEpochMilli(t).atOffset(offset);
             default:
@@ -179,7 +190,12 @@ public final class Cleanse {
         try {
             switch (unit) {
             case SECONDS:
-                return Instant.ofEpochMilli((long)(t * 1000.0)).atOffset(offset);
+                if (t > TOO_BIG_EPOCH_SECONDS_D) {
+                    return Instant.ofEpochMilli((long)t).atOffset(offset);
+                }
+                else {
+                    return Instant.ofEpochMilli((long)(t * 1000.0)).atOffset(offset);
+                }
             case MILLISECONDS:
                 return Instant.ofEpochMilli((long)t).atOffset(offset);
             default:

--- a/src/test/java/org/bricolages/streaming/stream/processor/TimestampColumnProcessorTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/processor/TimestampColumnProcessorTest.java
@@ -115,6 +115,10 @@ public class TimestampColumnProcessorTest {
         // with fractional seconds
         assertEquals("2016-07-01T16:41:06.246+09:00", proc.processValue(Double.valueOf(1467358866.246D)));
         assertEquals("2016-07-01T16:41:06.246+09:00", proc.processValue("1467358866.246"));
+
+        // milliseconds for seconds
+        assertEquals("2020-07-15T18:53:53.123+09:00", proc.processValue(1594806833123L));
+        assertEquals("2020-07-15T18:53:53.123+09:00", proc.processValue(Double.valueOf(1594806833123L)));
     }
 
     @Test


### PR DESCRIPTION
現代のUnix timeより3桁多いUnix time（秒）は自動的にミリ秒と思って変換する。

既存のコードでミリ秒のUnix timeを秒だと思って変換すると、なぜか `+52506-04-19` のような変な日付が出力されていろいろ死んだ。 `+` が入るのがちょっと謎だが、ひとまずよきにはからって対応する。