### PR TITLE
Rejects too long rows (>4MB), Redshift does not accept them for loading

### DIFF
--- a/src/main/java/org/bricolages/streaming/stream/PacketFilter.java
+++ b/src/main/java/org/bricolages/streaming/stream/PacketFilter.java
@@ -9,6 +9,7 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.PrintWriter;
 import java.util.regex.Pattern;
+import java.nio.charset.StandardCharsets;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -95,7 +96,10 @@ public class PacketFilter {
         }
     }
 
+    static final long REDSHIFT_LOAD_RECORD_LIMIT = 4194304;  // 4MB
+
     public String processJSON(String json, PacketFilterResult result) throws JSONParseException {
+        if (json.getBytes(StandardCharsets.UTF_8).length > REDSHIFT_LOAD_RECORD_LIMIT) return null;
         Record record = Record.parse(json);
         if (record == null) return null;
         Record outRecord = processRecord(record, result);

--- a/src/test/java/org/bricolages/streaming/stream/PacketFilterTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/PacketFilterTest.java
@@ -25,6 +25,7 @@ public class PacketFilterTest {
             "{\"int_col\":1,\"bigint_col\":99}\n" +
             "{\n" +
             "{\"int_col\":1,\"bigint_col\":\"b\"}\n" +
+            "{\"text_col\":\"" + "a".repeat(4194304) + "\"}\n" +
             "{\"text_col\":\"aaaaaaaaaaaaaaaaaaaaaaaaa\"}\n";
         val in = new BufferedReader(new StringReader(src));
 
@@ -40,7 +41,7 @@ public class PacketFilterTest {
         bufOut.close();
 
         assertEquals(expected, out.toString());
-        assertEquals(5, r.getInputRows());
+        assertEquals(6, r.getInputRows());
         assertEquals(3, r.getOutputRows());
         assertEquals(1, r.getErrorRows());
     }


### PR DESCRIPTION
4MBを越える行があるとファイル全体のロードが止まるので、長い行を除外する。

Spectrumでは問題ない可能性があるのが悩みどころだが、ひとまずロードが成功するほうを優先する。
オプションとかにすると、多少マシかもしれない。