### PR TITLE
new: Rejects unknown streams which have an invalid name

### DIFF
--- a/src/main/java/org/bricolages/streaming/stream/PacketRouter.java
+++ b/src/main/java/org/bricolages/streaming/stream/PacketRouter.java
@@ -127,6 +127,11 @@ public class PacketRouter {
         if (components == null) return null;
         if (components.isEmpty()) return Route.makeBlackhole();
 
+        if (isBadStreamName(components.streamName)) {
+            logBadStreamName(components.streamName);
+            return null;
+        }
+
         PacketStream stream = streamRepos.findStream(components.streamName);
         if (stream == null) {
             // If a stream does not exist, its corresponding table does not exist, too.
@@ -212,5 +217,15 @@ public class PacketRouter {
 
     public void logUnknownS3Object(S3ObjectLocator loc) {
         log.warn("unknown S3 object URL: {}", loc);
+    }
+
+    static final Pattern STREAM_NAME = Pattern.compile("[a-zA-Z]\\w*\\.[a-zA-Z]\\w*");
+
+    static boolean isBadStreamName(String streamName) {
+        return ! STREAM_NAME.matcher(streamName).matches();
+    }
+
+    public void logBadStreamName(String streamName) {
+        log.warn("bad stream name, ignore: {}", streamName);
     }
 }

--- a/src/test/java/org/bricolages/streaming/stream/PacketRouterTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/PacketRouterTest.java
@@ -171,4 +171,21 @@ public class PacketRouterTest {
         assertNotNull(result);
         assertEquals(true, result.isBlackhole());
     }
+
+    @Test
+    public void isBadStreamName() throws Exception {
+        assertFalse(PacketRouter.isBadStreamName("schema.table"));
+        assertFalse(PacketRouter.isBadStreamName("schema_name.table_name"));
+        assertFalse(PacketRouter.isBadStreamName("schema_name.table2"));
+        assertFalse(PacketRouter.isBadStreamName("schema_name.table_name2"));
+        assertFalse(PacketRouter.isBadStreamName("a_bit_long_schema_name.really_very_long_log_table_name"));
+
+        assertTrue(PacketRouter.isBadStreamName(""));
+        assertTrue(PacketRouter.isBadStreamName("stream"));
+        assertTrue(PacketRouter.isBadStreamName("stream_name"));
+        assertTrue(PacketRouter.isBadStreamName("schema.123456"));
+        assertTrue(PacketRouter.isBadStreamName("schema.table-name"));
+        assertTrue(PacketRouter.isBadStreamName("schema.stream[new]"));
+        assertTrue(PacketRouter.isBadStreamName("42.log_table_name"));
+    }
 }


### PR DESCRIPTION
Should reject a new, unknown stream whose name are invalid, such like digits-only name or name with symbols.

- valid: schema.table
- valid: schema_name.table_name2
- INVALID: log_table
- INVALID: schema.123456
- INVALID: schema.4table
- INVALID: schema.table[key]

We should especially pay attention to `log_table` case, this is invalid.