### PR TITLE
new: Ignores invalid column name

### DIFF
--- a/src/main/java/org/bricolages/streaming/preproc/Preprocessor.java
+++ b/src/main/java/org/bricolages/streaming/preproc/Preprocessor.java
@@ -10,6 +10,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.util.Objects;
+import java.util.Set;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 
@@ -242,7 +243,7 @@ public class Preprocessor implements EventHandlers {
 
             deleteMessage(msg, event);
 
-            columnRepos.saveUnknownColumns(route.getStream(), result.getUnknownColumns());
+            saveUnknownColumns(route.getStream(), result.getUnknownColumns());
         }
         catch (ObjectIOException | ConfigError ex) {
             log.error("src: {}, error: {}", src.toString(), ex.getMessage());
@@ -295,5 +296,13 @@ public class Preprocessor implements EventHandlers {
 
         chunk.changeStateToDispatched();
         chunkRepos.save(chunk);
+    }
+
+    void saveUnknownColumns(PacketStream stream, Set<String> columns) {
+        for (String column : columns) {
+           if (StreamColumn.isValidColumnName(column)) {
+               columnRepos.saveUnknownColumn(stream, column);
+            }
+        }
     }
 }

--- a/src/main/java/org/bricolages/streaming/stream/StreamColumn.java
+++ b/src/main/java/org/bricolages/streaming/stream/StreamColumn.java
@@ -4,8 +4,11 @@ import org.bricolages.streaming.stream.processor.ProcessorParams;
 import org.bricolages.streaming.stream.processor.ProcessorContext;
 import org.bricolages.streaming.exception.*;
 import java.sql.Timestamp;
+import java.util.regex.Pattern;
 import javax.persistence.*;
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor
@@ -14,6 +17,12 @@ import lombok.extern.slf4j.Slf4j;
 @Entity
 @Table(name="strload_columns", uniqueConstraints=@UniqueConstraint(columnNames={"stream_id", "column_name"}))
 public class StreamColumn implements ProcessorParams {
+    static final Pattern VALID_NAME = Pattern.compile("[a-zA-Z]\\w*");
+
+    static public boolean isValidColumnName(String name) {
+        return VALID_NAME.matcher(name).matches();
+    }
+
     @Id
     @GeneratedValue(strategy=GenerationType.IDENTITY)
     @Column(name="column_id", nullable=false)

--- a/src/main/java/org/bricolages/streaming/stream/StreamColumnRepository.java
+++ b/src/main/java/org/bricolages/streaming/stream/StreamColumnRepository.java
@@ -2,10 +2,7 @@ package org.bricolages.streaming.stream;
 import org.bricolages.streaming.util.SQLUtils;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.dao.DataIntegrityViolationException;
-import java.util.Date;
-import java.util.Set;
 import java.util.List;
-import java.sql.Timestamp;
 import lombok.*;
 
 public interface StreamColumnRepository extends JpaRepository<StreamColumn, Long> {
@@ -14,12 +11,6 @@ public interface StreamColumnRepository extends JpaRepository<StreamColumn, Long
     }
 
     List<StreamColumn> findByStreamIdOrderById(long streamId);
-
-    public default void saveUnknownColumns(PacketStream stream, Set<String> names) {
-        for (String name : names) {
-            saveUnknownColumn(stream, name);
-        }
-    }
 
     public default StreamColumn saveUnknownColumn(PacketStream stream, String name) {
         val params = new StreamColumn.Params();

--- a/src/test/java/org/bricolages/streaming/stream/StreamColumnRepositoryTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/StreamColumnRepositoryTest.java
@@ -1,21 +1,12 @@
 package org.bricolages.streaming.stream;
 import org.bricolages.streaming.exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.boot.test.autoconfigure.orm.jpa.*;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.Date;
-import java.util.List;
-import java.util.ArrayList;
-import java.sql.Timestamp;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import static org.junit.Assert.*;
-import lombok.*;
-import org.springframework.transaction.annotation.Transactional;
-import org.hibernate.Hibernate;
+import lombok.val;
 
 @DataJpaTest
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -25,12 +16,15 @@ public class StreamColumnRepositoryTest {
     @Autowired StreamColumnRepository columnRepos;
 
     @Test
-    public void saveUnknownColumns() throws Exception {
+    public void saveUnknownColumn() throws Exception {
         val s = new PacketStream("schema.table");
         s.initialized = true;
         s.columnInitialized = true;
         val stream = entityManager.persist(s);
-        columnRepos.saveUnknownColumns(stream, nameSet("a", "b", "c"));
+
+        columnRepos.saveUnknownColumn(stream, "a");
+        columnRepos.saveUnknownColumn(stream, "b");
+        columnRepos.saveUnknownColumn(stream, "c");
 
         val columns = columnRepos.findColumns(stream);
         assertEquals(3, columns.size());
@@ -46,8 +40,10 @@ public class StreamColumnRepositoryTest {
         s.columnInitialized = true;
         val stream = entityManager.persist(s);
 
-        columnRepos.saveUnknownColumns(stream, nameSet("a", "b"));
-        columnRepos.saveUnknownColumns(stream, nameSet("b", "c"));
+        columnRepos.saveUnknownColumn(stream, "a");
+        columnRepos.saveUnknownColumn(stream, "b");
+        columnRepos.saveUnknownColumn(stream, "b");
+        columnRepos.saveUnknownColumn(stream, "c");
 
         entityManager.clear();
         val columns = columnRepos.findColumns(stream);
@@ -55,13 +51,5 @@ public class StreamColumnRepositoryTest {
         assertEquals("a", columns.get(0).getName());
         assertEquals("b", columns.get(1).getName());
         assertEquals("c", columns.get(2).getName());
-    }
-
-    Set<String> nameSet(String... names) {
-        val set = new HashSet<String>();
-        for (val n : names) {
-            set.add(n);
-        }
-        return set;
     }
 }

--- a/src/test/java/org/bricolages/streaming/stream/StreamColumnTest.java
+++ b/src/test/java/org/bricolages/streaming/stream/StreamColumnTest.java
@@ -1,0 +1,22 @@
+package org.bricolages.streaming.stream;
+import org.bricolages.streaming.exception.*;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+public class StreamColumnTest {
+    @Test
+    public void isValidColumnName() throws Exception {
+        assertTrue(StreamColumn.isValidColumnName("column"));
+        assertTrue(StreamColumn.isValidColumnName("column22"));
+        assertFalse(StreamColumn.isValidColumnName(""));
+        assertFalse(StreamColumn.isValidColumnName("column[key]"));
+        assertFalse(StreamColumn.isValidColumnName("1column"));
+        assertFalse(StreamColumn.isValidColumnName("12345"));
+        assertFalse(StreamColumn.isValidColumnName("column-name"));
+        assertFalse(StreamColumn.isValidColumnName("column name"));
+        assertFalse(StreamColumn.isValidColumnName(" column_name"));
+    }
+}


### PR DESCRIPTION
Now we ignore invalid column names, such like "name[key]", "12345".  They are not saved in the database further.