### PR TITLE
[Fix][Preflight] could not intern type name: timestamptz

### DIFF
--- a/src/main/java/org/bricolages/streaming/preflight/domains/TimestamptzDomain.java
+++ b/src/main/java/org/bricolages/streaming/preflight/domains/TimestamptzDomain.java
@@ -19,7 +19,7 @@ public class TimestamptzDomain extends PrimitiveDomain {
     @MultilineDescription("Target timezone, given by the string like '+09:00'")
     private String targetOffset;
 
-    @Getter private final String type = "timestamptz";
+    @Getter private final String type = "timestamp";
     @Getter private final ColumnEncoding encoding = ColumnEncoding.ZSTD;
 
     @Getter private final boolean partitionSource = false;


### PR DESCRIPTION
When I run preflight for a .strdef file which contains timestamptz
domain it throws following error.

```
preflight: error: event_time column: could not intern type name: timestamptz
```

We don't have timestamptz column type with preprocessor and timestamptz
should be mapped to timestamp type.